### PR TITLE
Fix parsing error "FormatException: Invalid radix-16 number" on some avatars

### DIFF
--- a/lib/multiavatar.dart
+++ b/lib/multiavatar.dart
@@ -1017,7 +1017,7 @@ String multiavatar(String string, {bool trBackground = false}) {
     for (var i = 0; i < result.length; i++) {
       // print("change: ${result[i]} ===> with: ${colors[i]}");
       resultFinal =
-          resultFinal.replaceFirst(result[i] ?? "", colors?[i] ?? "" + ';');
+          resultFinal.replaceFirst(result[i] ?? "", (colors?[i] ?? "") + ';');
     }
 
     return resultFinal;


### PR DESCRIPTION
Some avatars fail to be parsed by the the `flutter_svg` library because colour replacement for themes sometimes removes semicolons, causing invalid style:

What gets outputted (causes error): `style="fill:#fffstroke-linecap:round;...`
What should get outputted (after fix): `style="fill:#fff;stroke-linecap:round;...`

This is due to the order of operations with the null coalescing operator:
`null ?? "" + ";"` resolves to `;`
`"not null" ?? "" + ";"` resolves to `not null`